### PR TITLE
Enable Rimworld of Magic (again)

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -32,27 +32,18 @@
 	<v1.6>
 		<!-- base stuff (things that are almost the same each version) -->
 		<li>/</li>
-		<li>Common</li>
-
-		<!-- version specific -->
 		<li>1.6</li>
+		<li>Common</li>
 		
 		<!-- content adding things -->
 		<li IfModActive="aelanna.endling">1.6/Mods/Endling</li>
-<<<<<<< HEAD
-		<!-- <li IfModActive="torann.arimworldofmagic">1.6/Mods/RoM/</li> -->
-		<!-- <li IfModActive="kure.arom">1.6/Mods/RoM_Addons/kure</li> 		-->
+		<li IfModActive="torann.arimworldofmagic">1.6/Mods/RoM/</li>
+		<li IfModActive="kure.arom">1.6/Mods/RoM_Addons/kure</li> 		
 		<li IfModActive="chtech.opthings.pack">1.6/Mods/OpThingAMajing</li> <!-- nothing yet -->
 		<li IfModActive="vanillaexpanded.vpsycastse">1.6/Mods/VPE/</li> <!-- vanilla psycasts expanded compat -->
 		
 		<!-- <li IfModActive="mlie.reinforcedmechanoid2">GestaltScen</li> -->
 			<!-- commented out until this mod is updated to 1.6 -->
 		<!-- if reinforced mechanoids 2 is there, add scenario (used to be another mod) -->			
-=======
-		<li IfModActive="torann.arimworldofmagic">1.6/Mods/RoM/</li>
-		<li IfModActive="kure.arom">1.6/Mods/RoM_Addons/kure</li> 		
-		<li IfModActive="chtech.opthings.pack">1.6/Mods/OpThingAMajing</li> <!-- nothing yet -->
-		<li IfModActive="vanillaexpanded.vpsycastse">1.6/Mods/VPE/</li>
->>>>>>> parent of 5b405d3 (Update LoadFolders.xml)
 	<v1.6>
 </loadFolders>


### PR DESCRIPTION
this enables rimworld of magic. Just, now it doesn't have cross-refferenses that shouldn't be there (yet)!